### PR TITLE
Updating app requirements for Django 1.8 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
The Django version in the requirements has been upgraded to version 1.8.
django-cms>=3.1.1 is now required for Django 1.8 support. A fork of
django-shop is also required for Django 1.8 support.
The test settings have also been updated to reflect this upgrade.