### PR TITLE
Adding CMS PlaceholderFields for the Catalog model.

### DIFF
--- a/shop_richcatalog/migrations/0003_auto_20160316_0846.py
+++ b/shop_richcatalog/migrations/0003_auto_20160316_0846.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import cms.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0013_urlconfrevision'),
+        ('shop_richcatalog', '0002_catalogplugin'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='catalog',
+            name='above_catalog_placeholder',
+            field=cms.models.fields.PlaceholderField(related_name='above_catalog_placeholder', slotname=b'above_catalog_placeholder', editable=False, to='cms.Placeholder', null=True),
+        ),
+        migrations.AddField(
+            model_name='catalog',
+            name='below_catalog_placeholder',
+            field=cms.models.fields.PlaceholderField(related_name='below_catalog_placeholder', slotname=b'below_catalog_placeholder', editable=False, to='cms.Placeholder', null=True),
+        ),
+    ]

--- a/shop_richcatalog/models.py
+++ b/shop_richcatalog/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from mptt.models import MPTTModel, TreeForeignKey
 from shop.models import Product
 from cms.models import CMSPlugin
+from cms.models.fields import PlaceholderField
 
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
@@ -29,6 +30,14 @@ class Catalog(MPTTModel):
 
     description = models.CharField(max_length=255)
     image = models.ImageField(upload_to="rich_catalog", null=True, blank=True)
+
+    above_catalog_placeholder = PlaceholderField(
+        'above_catalog_placeholder',
+        related_name='above_catalog_placeholder')
+
+    below_catalog_placeholder = PlaceholderField(
+        'below_catalog_placeholder',
+        related_name='below_catalog_placeholder')
 
     class Meta(object):
         verbose_name = _("Catalog")


### PR DESCRIPTION
This PR adds PlaceholderFields because Django CMS Apphooked
views can not make use of the placeholders that appear in inherited
templates. These new PlaceholderFields allow further customization of
each Catalog's detail view.